### PR TITLE
refactor(logging): Use lastResort as default handler for root logger

### DIFF
--- a/openworld/sdk/core/__init__.py
+++ b/openworld/sdk/core/__init__.py
@@ -14,11 +14,8 @@
 
 import logging
 
+default_formatter = logging.Formatter(fmt="[%(asctime)s] %(name)s %(levelname)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+logging.lastResort.setFormatter(default_formatter)
+
 logging.lastResort.setLevel(logging.NOTSET)
-logging.lastResort.setFormatter(
-    logging.Formatter(
-        fmt="[%(asctime)s] %(name)s %(levelname)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S"
-    )
-)
 logging.root.setLevel(logging.NOTSET)

--- a/openworld/sdk/core/__init__.py
+++ b/openworld/sdk/core/__init__.py
@@ -13,19 +13,12 @@
 # limitations under the License.
 
 import logging
-from logging.config import fileConfig
 
-try:
-    with open(file="logging.cfg", mode="r+") as f:
-        fileConfig(f)
-except FileNotFoundError:
-    default_logger_handler = logging.StreamHandler()
-    default_formatter = logging.Formatter(
+logging.lastResort.setLevel(logging.NOTSET)
+logging.lastResort.setFormatter(
+    logging.Formatter(
         fmt="[%(asctime)s] %(name)s %(levelname)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+        datefmt="%Y-%m-%d %H:%M:%S"
     )
-    default_logger_handler.setFormatter(default_formatter)
-
-    default_logger = logging.getLogger(name="openworld")
-    default_logger.addHandler(default_logger_handler)
-    default_logger.setLevel(level=logging.DEBUG)
+)
+logging.root.setLevel(logging.NOTSET)


### PR DESCRIPTION
<!--
Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [] There are new or updated unit tests validating the change.
-->

### :pencil: Description
- Use lastResort as default handler for root logger.

### :link: Related Issues
- 
