### PR TITLE
chore(generator): Use Classname Literal for Type Attributes in Inheritance Instead of Enums.

### DIFF
--- a/openworld/sdk/generator/client/visitors/models.py
+++ b/openworld/sdk/generator/client/visitors/models.py
@@ -129,9 +129,7 @@ def copy_parent_fields_to_child(parent: DataModel, child: DataModel) -> DataMode
             continue
 
         literal = DataType(type=f'Literal["{child.class_name}"]')
-
-        if not field.data_type.reference:
-            field.data_type = DataType(data_types=[literal])
+        field.data_type = DataType(data_types=[literal])
         break
 
     return child


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [] There are new or updated unit tests validating the change.

### :pencil: Description
- Use Classname Literal for Type Attributes in Inheritance Instead of Enums.