### PR TITLE
fix(generator): Set version of `urllib3` to `1.26.15` till `requests` supports `urllib3>=2.0.0`.

### DIFF
--- a/openworld/sdk/core/requirements.txt
+++ b/openworld/sdk/core/requirements.txt
@@ -1,3 +1,4 @@
 uri~=2.0.1
 requests~=2.28.1
 pydantic==1.10.7
+urllib3==1.26.15


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Sets version of `urllib3` to `1.26.15` till `requests` supports `urllib3>=2.0.0`.

### :link: Related Issues
- https://github.com/psf/requests/issues/6432
